### PR TITLE
Fix XPath quoting in :contains()

### DIFF
--- a/pyquery/cssselectpatch.py
+++ b/pyquery/cssselectpatch.py
@@ -224,6 +224,6 @@ class JQueryTranslator(cssselect_xpath.HTMLTranslator):
                 "Expected a single string for :contains(), got %r" % (
                     function.arguments,))
 
-        value = function.arguments[0].value
-        xpath.add_post_condition("contains(text(), '%s')" % value)
+        value = self.xpath_literal(function.arguments[0].value)
+        xpath.add_post_condition("contains(text(), %s)" % value)
         return xpath


### PR DESCRIPTION
The `xpath_literal()` method returns a valid, string-typed XPath expression for any string value, even on values that contains both `'` and `"` characters.

This change is untested, but see cssselect’s [test_unicode_escpapes](https://github.com/SimonSapin/cssselect/blob/1b95a44cd990abe3682b8c2ec250478d3673fd97/cssselect/tests.py#L427) for example of test cases.
