### PR TITLE
Fix #51: identifier instead of a quoted string in :contains()

### DIFF
--- a/pyquery/cssselectpatch.py
+++ b/pyquery/cssselectpatch.py
@@ -221,8 +221,8 @@ class JQueryTranslator(cssselect_xpath.HTMLTranslator):
         """
         if function.argument_types() not in (['STRING'], ['IDENT']):
             raise ExpressionError(
-                "Expected a single string for :contains(), got %r" % (
-                    function.arguments,))
+                "Expected a single string or identifier for "
+                ":contains(), got %r" % (function.arguments,))
 
         value = self.xpath_literal(function.arguments[0].value)
         xpath.add_post_condition("contains(text(), %s)" % value)


### PR DESCRIPTION
Although `:contains()` only exists in [an early draft](http://www.w3.org/TR/2001/CR-css3-selectors-20011113/#content-selectors) of the Selectors spec, it is specified as taking argument that is either a quoted string or an identifier.

This is untested, but I fairly confident it is correct as [the same code](https://github.com/SimonSapin/cssselect/blob/1b95a44/cssselect/xpath.py#L414) is [tested in cssselect](https://github.com/SimonSapin/cssselect/blob/master/cssselect/tests.py#L354).
