### PR TITLE
Fix whitespace issue in test_pyquery.py

### DIFF
--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -379,13 +379,11 @@ class TestManipulating(TestCase):
 
 class TestHTMLParser(TestCase):
     xml = "<div>I'm valid XML</div>"
-    html = '''
-    <div class="portlet">
+    html = '''<div class="portlet">
       <a href="/toto">TestimageMy link text</a>
       <a href="/toto2">imageMy link text 2</a>
       Behind you, a three-headed HTML&dash;Entity!
-    </div>
-    '''
+    </div>'''
 
     def test_parser_persistance(self):
         d = pq(self.xml, parser='xml')


### PR DESCRIPTION
This resolves two broken tests for me:
- test_replaceWith,
- test_replaceWith_with_function

Fixes #62. Tested in py26,27,32,33,34 (with tox and plain nosetests)
