### PR TITLE
support for keyword arguments in PyQuery custom functions (PyQuery.fn); hook tests

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1393,9 +1393,9 @@ class PyQuery(list):
 
         """
         def __setattr__(self, name, func):
-            def fn(self, *args):
+            def fn(self, *args, **kwargs):
                 func_globals(func)['this'] = self
-                return func(*args)
+                return func(*args, **kwargs)
             fn.__name__ = name
             setattr(PyQuery, name, fn)
     fn = Fn()

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -309,6 +309,32 @@ class TestCallback(TestCase):
                                      ['Coffee', 'Tea', 'Milk'])
 
 
+class TestHook(TestCase):
+    html = """
+        <ol>
+            <li>Coffee</li>
+            <li>Tea</li>
+            <li>Milk</li>
+        </ol>
+    """
+
+    def test_fn(self):
+        "Example from `PyQuery.Fn` docs."
+        fn = lambda: this.map(lambda i, el: pq(this).outerHtml())
+        pq.fn.listOuterHtml = fn
+        S = pq(self.html)
+        self.assertEqual(S('li').listOuterHtml(),
+                         ['<li>Coffee</li>', '<li>Tea</li>', '<li>Milk</li>'])
+
+    def test_fn_with_kwargs(self):
+        "fn() with keyword arguments."
+        pq.fn.test = lambda p=1: pq(this).eq(p)
+        S = pq(self.html)
+        self.assertEqual(S('li').test(0).text(), 'Coffee')
+        self.assertEqual(S('li').test().text(), 'Tea')
+        self.assertEqual(S('li').test(p=2).text(), 'Milk')
+
+
 class TestAjaxSelector(TestSelector):
     klass = pqa
 


### PR DESCRIPTION
Keyword args support in custom fn.
Hook tests (new TestCase), including a test for kwargs from this commit.
