### PR TITLE
fix append by suggestion from suhaliv

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1130,7 +1130,6 @@ class PyQuery(list):
             if i > 0:
                 root = deepcopy(list(root))
             tag.extend(root)
-            root = tag[-len(root):]
         return self
 
     @with_camel_case_alias


### PR DESCRIPTION
remove line root=tag[-len(root):]
this is suggested by @suhailv, I test the modification with unittest and it didn't break any test.
I think this is safe to remove.
