### PR TITLE
Raise a TypeError when passed invalid types

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -251,6 +251,8 @@ class PyQuery(list):
                 elements = context
             elif isinstance(context, etree._Element):
                 elements = [context]
+            else:
+                raise TypeError(context)
 
             # select nodes
             if elements and selector is not no_default:

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -285,6 +285,12 @@ class TestOpener(TestCase):
         assert len(doc('.node')) == 1, doc
 
 
+class TestConstruction(TestCase):
+
+    def test_typeerror_on_invalid_value(self):
+        self.assertRaises(TypeError, pq, object())
+
+
 class TestComment(TestCase):
 
     def test_comment(self):


### PR DESCRIPTION
not super critical, figured this should raise when receiving garbage instead of silently returning a list