### PR TITLE
text() output compatible with selenium .text property #99

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ parts/
 # Temporary files
 *~
 
+# Log files
+geckodriver.log
+
 # Sphinx documentation
 docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ install:
 script:
   - tox
 after_success:
+# env:
+#   - MOZ_HEADLESS=1
+# addons:
+#   firefox: latest

--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -5,6 +5,7 @@
 # Distributed under the BSD license, see LICENSE.txt
 from .cssselectpatch import JQueryTranslator
 from .openers import url_opener
+from .text import extract_text
 from copy import deepcopy
 from lxml import etree
 import lxml.html
@@ -1130,12 +1131,15 @@ class PyQuery(list):
             e0.tail = ''
         return etree.tostring(e0, encoding=text_type, method=method)
 
-    def text(self, value=no_default):
+    def text(self, value=no_default, **kwargs):
         """Get or set the text representation of sub nodes.
 
         Get the text value::
 
             >>> doc = PyQuery('<div><span>toto</span><span>tata</span></div>')
+            >>> print(doc.text())
+            tototata
+            >>> doc = PyQuery('<div><span>toto</span>       <span>tata</span></div>')
             >>> print(doc.text())
             toto tata
 
@@ -1151,20 +1155,7 @@ class PyQuery(list):
         if value is no_default:
             if not self:
                 return ''
-
-            text = []
-
-            def add_text(tag, no_tail=False):
-                if tag.text and not isinstance(tag, lxml.etree._Comment):
-                    text.append(tag.text)
-                for child in tag.getchildren():
-                    add_text(child)
-                if not no_tail and tag.tail:
-                    text.append(tag.tail)
-
-            for tag in self:
-                add_text(tag, no_tail=True)
-            return ' '.join([t.strip() for t in text if t.strip()])
+            return ' '.join(extract_text(tag, **kwargs) for tag in self)
 
         for tag in self:
             for child in tag.getchildren():

--- a/pyquery/text.py
+++ b/pyquery/text.py
@@ -1,0 +1,105 @@
+import re
+
+
+# https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#Elements
+INLINE_TAGS = {
+    'a', 'abbr', 'acronym', 'b', 'bdo', 'big', 'br', 'button', 'cite',
+    'code', 'dfn', 'em', 'i', 'img', 'input', 'kbd', 'label', 'map',
+    'object', 'q', 'samp', 'script', 'select', 'small', 'span', 'strong',
+    'sub', 'sup', 'textarea', 'time', 'tt', 'var'
+}
+
+SEPARATORS = {'br'}
+
+
+# Definition of whitespace in HTML:
+# https://www.w3.org/TR/html4/struct/text.html#h-9.1
+WHITESPACE_RE = re.compile('[\x20\x09\x0C\u200B\x0A\x0D]+')
+
+
+def squash_html_whitespace(text):
+    # use raw extract_text for preformatted content (like <pre> content or set by CSS rules)
+    # apply this function on top of
+    return WHITESPACE_RE.sub(' ', text)
+
+
+def _squash_artifical_nl(parts):
+    output, last_nl = [], False
+    for x in parts:
+        if x is not None:
+            output.append(x)
+            last_nl = False
+        elif not last_nl:
+            output.append(None)
+            last_nl = True
+    return output
+
+
+def _strip_artifical_nl(parts):
+    if not parts:
+        return parts
+    for start_idx, pt in enumerate(parts):
+        if isinstance(pt, str):  # 0, 1, 2, index of first string [start_idx:...
+            break
+    for end_idx, pt in enumerate(parts[:start_idx - 1 if start_idx > 0 else None:-1]):
+        if isinstance(pt, str):  # 0=None, 1=-1, 2=-2, index of last string
+            break
+    return parts[start_idx:-end_idx if end_idx > 0 else None]
+
+
+def _merge_original_parts(parts):
+    output, orp_buf = [], []
+
+    def flush():
+        if orp_buf:
+            item = squash_html_whitespace(''.join(orp_buf)).strip()
+            if item:
+                output.append(item)
+            orp_buf.clear()
+
+    for x in parts:
+        if not isinstance(x, str):
+            flush()
+            output.append(x)
+        else:
+            orp_buf.append(x)
+    flush()
+    return output
+
+
+def extract_text_array(dom, squash_artifical_nl=True, strip_artifical_nl=True):
+    if callable(dom.tag):
+        return ''
+    r = []
+    if dom.tag in SEPARATORS:
+        r.append(True)  # equivalent of '\n' used to designate separators
+    elif dom.tag not in INLINE_TAGS:
+        r.append(None)  # equivalent of '\n' used to designate artifically inserted newlines
+    if dom.text is not None:
+        r.append(dom.text)
+    for child in dom.getchildren():
+        r.extend(extract_text_array(child, squash_artifical_nl=False, strip_artifical_nl=False))
+        if child.tail is not None:
+            r.append(child.tail)
+    if dom.tag not in INLINE_TAGS and dom.tag not in SEPARATORS:
+        r.append(None)  # equivalent of '\n' used to designate artifically inserted newlines
+    if squash_artifical_nl:
+        r = _squash_artifical_nl(r)
+    if strip_artifical_nl:
+        r = _strip_artifical_nl(r)
+    return r
+
+
+def extract_text(dom, block_symbol='\n', sep_symbol='\n', squash_space=True):
+    a = extract_text_array(dom, squash_artifical_nl=squash_space)
+    if squash_space:
+        a = _strip_artifical_nl(_squash_artifical_nl(_merge_original_parts(a)))
+    result = ''.join(
+        block_symbol if x is None else (
+            sep_symbol if x is True else x
+        )
+        for x in a
+    )
+    if squash_space:
+        result = result.strip()
+    return result

--- a/pyquery/text.py
+++ b/pyquery/text.py
@@ -18,7 +18,8 @@ WHITESPACE_RE = re.compile('[\x20\x09\x0C\u200B\x0A\x0D]+')
 
 
 def squash_html_whitespace(text):
-    # use raw extract_text for preformatted content (like <pre> content or set by CSS rules)
+    # use raw extract_text for preformatted content (like <pre> content or set
+    # by CSS rules)
     # apply this function on top of
     return WHITESPACE_RE.sub(' ', text)
 
@@ -39,9 +40,11 @@ def _strip_artifical_nl(parts):
     if not parts:
         return parts
     for start_idx, pt in enumerate(parts):
-        if isinstance(pt, str):  # 0, 1, 2, index of first string [start_idx:...
+        if isinstance(pt, str):
+            # 0, 1, 2, index of first string [start_idx:...
             break
-    for end_idx, pt in enumerate(parts[:start_idx - 1 if start_idx > 0 else None:-1]):
+    iterator = enumerate(parts[:start_idx - 1 if start_idx > 0 else None:-1])
+    for end_idx, pt in iterator:
         if isinstance(pt, str):  # 0=None, 1=-1, 2=-2, index of last string
             break
     return parts[start_idx:-end_idx if end_idx > 0 else None]
@@ -55,7 +58,7 @@ def _merge_original_parts(parts):
             item = squash_html_whitespace(''.join(orp_buf)).strip()
             if item:
                 output.append(item)
-            orp_buf.clear()
+            orp_buf[:] = []
 
     for x in parts:
         if not isinstance(x, str):
@@ -74,15 +77,18 @@ def extract_text_array(dom, squash_artifical_nl=True, strip_artifical_nl=True):
     if dom.tag in SEPARATORS:
         r.append(True)  # equivalent of '\n' used to designate separators
     elif dom.tag not in INLINE_TAGS:
-        r.append(None)  # equivalent of '\n' used to designate artifically inserted newlines
+        # equivalent of '\n' used to designate artifically inserted newlines
+        r.append(None)
     if dom.text is not None:
         r.append(dom.text)
     for child in dom.getchildren():
-        r.extend(extract_text_array(child, squash_artifical_nl=False, strip_artifical_nl=False))
+        r.extend(extract_text_array(child, squash_artifical_nl=False,
+                                    strip_artifical_nl=False))
         if child.tail is not None:
             r.append(child.tail)
     if dom.tag not in INLINE_TAGS and dom.tag not in SEPARATORS:
-        r.append(None)  # equivalent of '\n' used to designate artifically inserted newlines
+        # equivalent of '\n' used to designate artifically inserted newlines
+        r.append(None)
     if squash_artifical_nl:
         r = _squash_artifical_nl(r)
     if strip_artifical_nl:

--- a/pyquery/text.py
+++ b/pyquery/text.py
@@ -1,4 +1,16 @@
 import re
+import sys
+
+
+PY3k = sys.version_info >= (3,)
+
+
+if PY3k:
+    def is_string(s):
+        return isinstance(s, str)
+else:
+    def is_string(s):
+        return isinstance(s, (unicode, str))
 
 
 # https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#Elements
@@ -14,7 +26,7 @@ SEPARATORS = {'br'}
 
 # Definition of whitespace in HTML:
 # https://www.w3.org/TR/html4/struct/text.html#h-9.1
-WHITESPACE_RE = re.compile('[\x20\x09\x0C\u200B\x0A\x0D]+')
+WHITESPACE_RE = re.compile(u'[\x20\x09\x0C\u200B\x0A\x0D]+')
 
 
 def squash_html_whitespace(text):
@@ -40,12 +52,12 @@ def _strip_artifical_nl(parts):
     if not parts:
         return parts
     for start_idx, pt in enumerate(parts):
-        if isinstance(pt, str):
+        if is_string(pt):
             # 0, 1, 2, index of first string [start_idx:...
             break
     iterator = enumerate(parts[:start_idx - 1 if start_idx > 0 else None:-1])
     for end_idx, pt in iterator:
-        if isinstance(pt, str):  # 0=None, 1=-1, 2=-2, index of last string
+        if is_string(pt):  # 0=None, 1=-1, 2=-2, index of last string
             break
     return parts[start_idx:-end_idx if end_idx > 0 else None]
 
@@ -61,7 +73,7 @@ def _merge_original_parts(parts):
             orp_buf[:] = []
 
     for x in parts:
-        if not isinstance(x, str):
+        if not is_string(x):
             flush()
             output.append(x)
         else:

--- a/seleniumtests/base.py
+++ b/seleniumtests/base.py
@@ -1,0 +1,96 @@
+'''
+Integer quis commodo libero.
+Phasellus eget sem facilisis justo pellentesque venenatis.
+In sagittis rutrum condimentum.
+Praesent aliquam maximus erat vitae mattis.
+Curabitur vulputate ullamcorper nisi vel gravida.
+Morbi fringilla, diam non commodo mattis, nulla neque sollicitudin mi, in ullamcorper orci urna ac mauris.
+Vivamus consequat bibendum sollicitudin.
+Nullam rhoncus vel tortor sit amet vehicula.
+Ut a odio ac arcu placerat placerat.
+In ultricies erat et maximus mollis.
+Etiam vestibulum, odio venenatis dignissim ullamcorper, neque enim cursus erat, id accumsan orci est ac urna.
+'''
+
+
+class TextExtractionMixin():
+    def _prepare_dom(self, html):
+        self.last_html = '<html><body>' + html + '</body></html>'
+
+    def _simple_test(self, html, expected_sq, expected_nosq, **kwargs):
+        raise NotImplementedError
+
+    def test_inline_tags(self):
+        self._simple_test(
+            'Phas<em>ell</em>us<i> eget </i>sem <b>facilisis</b> justo',
+            'Phasellus eget sem facilisis justo',
+            'Phasellus eget sem facilisis justo',
+        )
+        self._simple_test(
+            'Phasellus <span> eget </span> sem <b>facilisis\n</b> justo',
+            'Phasellus eget sem facilisis justo',
+            'Phasellus  eget  sem facilisis\n justo',
+        )
+        self._simple_test(
+            'Phasellus   <span>\n  eget\n           sem\n\tfacilisis</span>   justo',
+            'Phasellus eget sem facilisis justo',
+            'Phasellus   \n  eget\n           sem\n\tfacilisis   justo'
+        )
+
+    def test_block_tags(self):
+        self._simple_test(
+            'Phas<p>ell</p>us<div> eget </div>sem <h1>facilisis</h1> justo',
+            'Phas\nell\nus\neget\nsem\nfacilisis\njusto',
+            'Phas\nell\nus\n eget \nsem \nfacilisis\n justo',
+        )
+        self._simple_test(
+            '<p>In sagittis</p> <p>rutrum</p><p>condimentum</p>',
+            'In sagittis\nrutrum\ncondimentum',
+            'In sagittis\n \nrutrum\n\ncondimentum',
+        )
+        self._simple_test(
+            'In <p>\nultricies</p>\n erat et <p>\n\n\nmaximus\n\n</p> mollis',
+            'In\nultricies\nerat et\nmaximus\nmollis',
+            'In \n\nultricies\n\n erat et \n\n\n\nmaximus\n\n\n mollis',
+        )
+        self._simple_test(
+            'Integer <div><div>\n  <div>quis commodo</div></div> </div> libero',
+            'Integer\nquis commodo\nlibero',
+            'Integer \n\n\n  \nquis commodo\n\n \n libero',
+        )
+        self._simple_test(
+            'Heading<ul><li>one</li><li>two</li><li>three</li></ul>',
+            'Heading\none\ntwo\nthree',
+            'Heading\n\none\n\ntwo\n\nthree',
+        )
+
+    def test_separators(self):
+        self._simple_test(
+            'Some words<br>test. Another word<br><br> <br> test.',
+            'Some words\ntest. Another word\n\n\ntest.',
+            'Some words\ntest. Another word\n\n \n test.',
+        )
+        self._simple_test(
+            'Inline <span>  splitted by\nbr<br>tag</span> test',
+            'Inline splitted by br\ntag test',
+            'Inline   splitted by\nbr\ntag test',
+        )
+        self._simple_test(
+            'Some words<hr>test. Another word<hr><hr> <hr> test.',
+            'Some words\ntest. Another word\ntest.',
+            'Some words\n\ntest. Another word\n\n\n\n \n\n test.',
+        )
+
+    def test_strip(self):
+        self._simple_test(
+            ' text\n',
+            'text',
+            ' text\n',
+        )
+
+    def test_ul_li(self):
+        self._simple_test(
+            '<ul> <li>  </li> </ul>',
+            '',
+            ' \n  \n '
+        )

--- a/seleniumtests/browser.py
+++ b/seleniumtests/browser.py
@@ -97,8 +97,6 @@ class TestInnerText(BaseBrowserTest, TextExtractionMixin):
     REQUEST_HANDLER_CLASS = HTMLSnippetSender
 
     def _simple_test(self, html, expected_sq, expected_nosq, **kwargs):
-        # super()._simple_test(html, expected_sq, expected_nosq, **kwargs)
-
         self.send_to_server(html)
         self.open_url('/')
 

--- a/seleniumtests/browser.py
+++ b/seleniumtests/browser.py
@@ -1,0 +1,107 @@
+import unittest
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from threading import Thread
+from queue import Queue
+from selenium import webdriver
+from time import sleep
+from urllib.parse import urlunsplit
+
+from .base import TextExtractionMixin
+
+
+class BaseTestRequestHandler(BaseHTTPRequestHandler):
+    _last_html = ''
+
+    def _get_last_html(self):
+        q = self.server.html_queue
+        while not q.empty():
+            self._last_html = q.get_nowait()
+        return self._last_html
+
+    def log_request(self, code='-', size='-'):
+        pass
+
+    def recv_from_testsuite(self, non_blocking=False):
+        q = self.server.in_queue
+        if non_blocking:
+            return None if q.empty() else q.get_nowait()
+        return q.get()
+
+    def send_to_testsuite(self, value):
+        self.server.out_queue.put(value)
+
+
+class HTMLSnippetSender(BaseTestRequestHandler):
+    last_html = b''
+
+    def get_last_html(self):
+        while True:
+            value = self.recv_from_testsuite(non_blocking=True)
+            if value is None:
+                break
+            self.last_html = value
+        return self.last_html
+
+    def do_GET(self):
+        if self.path == '/':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.end_headers()
+            self.wfile.write(self.get_last_html().encode('utf-8'))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+class BaseBrowserTest(unittest.TestCase):
+    LOCAL_IP = '127.0.0.1'
+    PORT = 28546
+    REQUEST_HANDLER_CLASS = None  # descendant of BaseBrowserTestRequestHandler
+
+    @classmethod
+    def setUpClass(cls):
+        cls.to_server_queue = Queue()
+        cls.from_server_queue = Queue()
+        cls.server = HTTPServer((cls.LOCAL_IP, cls.PORT), cls.REQUEST_HANDLER_CLASS)
+        cls.server.in_queue = cls.to_server_queue
+        cls.server.out_queue = cls.from_server_queue
+        cls.server_thread = Thread(target=cls.server.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+        # cls.driver = webdriver.Firefox()
+        cls.driver = webdriver.Chrome()
+        sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def send_to_server(self, value):
+        self.to_server_queue.put(value)
+
+    def recv_from_server(self, non_blocking=False):
+        q = self.from_server_queue
+        if non_blocking:
+            return None if q.empty() else q.get_nowait()
+        return q.get()
+
+    def open_url(self, path):
+        self.driver.get(urlunsplit(('http', '{}:{}'.format(self.LOCAL_IP, self.PORT), path, '', '')))
+
+
+class TestInnerText(BaseBrowserTest, TextExtractionMixin):
+    REQUEST_HANDLER_CLASS = HTMLSnippetSender
+
+    def _simple_test(self, html, expected_sq, expected_nosq, **kwargs):
+        # super()._simple_test(html, expected_sq, expected_nosq, **kwargs)
+
+        self.send_to_server(html)
+        self.open_url('/')
+
+        selenium_text = self.driver.find_element_by_tag_name('body').text
+        self.assertEqual(selenium_text, expected_sq)
+
+        # inner_text = self.driver.execute_script('return document.body.innerText')
+        # text_content = self.driver.execute_script('return document.body.textContent')

--- a/seleniumtests/browser.py
+++ b/seleniumtests/browser.py
@@ -3,6 +3,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from threading import Thread
 from queue import Queue
 from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
 from time import sleep
 from urllib.parse import urlunsplit
 
@@ -68,8 +69,9 @@ class BaseBrowserTest(unittest.TestCase):
         cls.server_thread = Thread(target=cls.server.serve_forever)
         cls.server_thread.daemon = True
         cls.server_thread.start()
-        # cls.driver = webdriver.Firefox()
-        cls.driver = webdriver.Chrome()
+        options = Options()
+        options.add_argument('-headless')
+        cls.driver = webdriver.Firefox(options=options)
         sleep(1)
 
     @classmethod

--- a/seleniumtests/offline.py
+++ b/seleniumtests/offline.py
@@ -1,0 +1,17 @@
+import unittest
+
+from pyquery.pyquery import PyQuery
+from .base import TextExtractionMixin
+
+
+class TestInnerText(unittest.TestCase, TextExtractionMixin):
+    def _prepare_dom(self, html):
+        super()._prepare_dom(html)
+        self.pq = PyQuery(self.last_html)
+
+    def _simple_test(self, html, expected_sq, expected_nosq, **kwargs):
+        self._prepare_dom(html)
+        text_sq = self.pq.text(squash_space=True, **kwargs)
+        text_nosq = self.pq.text(squash_space=False, **kwargs)
+        self.assertEqual(text_sq, expected_sq)
+        self.assertEqual(text_nosq, expected_nosq)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ doctest-extension = rst
 doctest-fixtures = _fixt
 # XXX: docs/index.txt requires lxml
 include = docs
+exclude = seleniumtests
 cover-package=pyquery
 with-coverage=1
 doctest-options = +ELLIPSIS,+NORMALIZE_WHITESPACE

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,10 @@ deps =
 commands =
     rm -Rf {envtmpdir}/doctrees {envtmpdir}/html
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[testenv:selenium]
+deps =
+    selenium
+commands =
+    {envbindir}/python -m unittest seleniumtests.offline
+    {envbindir}/python -m unittest seleniumtests.browser

--- a/tox.ini
+++ b/tox.ini
@@ -35,9 +35,10 @@ commands =
     rm -Rf {envtmpdir}/doctrees {envtmpdir}/html
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
-[testenv:selenium]
-deps =
-    selenium
-commands =
-    {envbindir}/python -m unittest seleniumtests.offline
-    {envbindir}/python -m unittest seleniumtests.browser
+# [testenv:selenium]
+# basepython = python3.5
+# deps =
+#     selenium
+# commands =
+#     {envbindir}/python -m unittest seleniumtests.offline
+#     {envbindir}/python -m unittest seleniumtests.browser


### PR DESCRIPTION
I'm not sure how to organize tests. They consist of two parts:
- testing selenium output to ensure correctness of TextExtractionMixin
- testing our code with same TextExtractionMixin

I don't know whether Travis supports selenium, so I put my tests separately.

```bash
python -m unittest seleniumtests.offline
python -m unittest seleniumtests.browser
```

Added same lines to tox config, but `browser` test hangs.
You can change selenium driver in `browser.py:71`. Recent Firefox hangs, but Chrome worked for me. Under tox both hang, probably due to lack of some envvars, like current X display.