### PR TITLE
Preserve tail text when calling html(content)

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1101,7 +1101,6 @@ class PyQuery(list):
                 if children:
                     tag.extend(children)
                 tag.text = root.text
-                tag.tail = root.tail
         return self
 
     @with_camel_case_alias

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -461,6 +461,18 @@ class TestManipulating(TestCase):
         d = pq('<input>')
         self.assertEqual(d.val(), '')
 
+    def test_html_replacement(self):
+        html = '<div>Not Me<span>Replace Me</span>Not Me</div>'
+        replacement = 'New <em>Contents</em> New'
+        expected = html.replace('Replace Me', replacement)
+
+        d = pq(html)
+        d.find('span').html(replacement)
+
+        new_html = d.outerHtml()
+        self.assertEqual(new_html, expected)
+        self.assertIn(replacement, new_html)
+
 
 class TestMakeLinks(TestCase):
 


### PR DESCRIPTION
As described in #102, calling `element.html(content)` currently deletes any tail text after the element, when it should only replace the contents of the element. This PR fixes that issue, and adds a test to verify that `element.html(content)` works as expected.

Fixes #102