### PR TITLE
Documentation for #181 - don't squash newlines

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1174,6 +1174,14 @@ class PyQuery(list):
             >>> print(doc.text())
             toto tata
 
+        Get the text value, without squashing newlines::
+
+            >>> doc = PyQuery('''<div><span>toto</span>
+            ...               <span>tata</span></div>''')
+            >>> print(doc.text(squash_space=False))
+            toto
+            tata
+
         Set the text value::
 
             >>> doc.text('Youhou !')


### PR DESCRIPTION
I also ran into the issue where `.text()` no longer returned newlines, and after digging through the code and experimenting a bit I found that setting the `squash_space` option to `False` fixed my issue.

This PR quickly documents that option.

This could be considered a "fix" to #181.