### PR TITLE
Fix make_links_absolute to support tel:, sms:

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1545,6 +1545,11 @@ class PyQuery(list):
                 if attr_value is None:
                     return None
 
+                # skip specific "protocol" schemas
+                if any(attr_value.startswith(schema)
+                       for schema in ('tel:', 'callto:', 'sms:')):
+                    return None
+
                 return self(e).attr(attr,
                                     urljoin(base_url, attr_value.strip()))
             return rep


### PR DESCRIPTION
Reproduce the bug with:
```
In [1]: from pyquery import PyQuery as pq

In [2]: html = '<a href="tel:1234">phone us</a>'

In [3]: p = pq(html)

In [4]: p.make_links_absolute('http://example.com')[0].attrib['href']
Out[4]: 'http://example.com/tel:1234'
```

After my patch:

```
In [9]: p.make_links_absolute('http://example.com')[0].attrib['href']
Out[9]: 'tel:1234'
```

(added support of the `tel:`, `sms:` (used by mobile/smartphone OSes) and `callto:` (used by Skype)

I found out about this one while using pyspider, it was keeping yielding weird URLs like `http://example.com/tel:1234` while the `tel:1234` was perfectly alright.

Reference: https://css-tricks.com/the-current-state-of-telephone-links/

It doesn't seem to be in the HTML standard, but is heavily used on various sites that provide contacts that were made with Apple's iOS in mind, which, I guess, started the whole thing

Sorry, just a quick fix, I'm too lazy to write tests :( Hope I met the code guidelines.