### PR TITLE
textarea's text/value should include HTML markup

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1017,7 +1017,7 @@ class PyQuery(list):
         def _get_value(tag):
             # <textarea>
             if tag.tag == 'textarea':
-                return self._copy(tag).text()
+                return self._copy(tag).html()
             # <select>
             elif tag.tag == 'select':
                 if 'multiple' in tag.attrib:
@@ -1194,7 +1194,10 @@ class PyQuery(list):
         if value is no_default:
             if not self:
                 return ''
-            return ' '.join(extract_text(tag, **kwargs) for tag in self)
+            return ' '.join(
+                self._copy(tag).html() if tag.tag == 'textarea' else
+                extract_text(tag, **kwargs) for tag in self
+            )
 
         for tag in self:
             for child in tag.getchildren():

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -385,7 +385,10 @@ class TestManipulating(TestCase):
     '''
 
     html3 = '''
-        <textarea>Spam</textarea>
+        <textarea id="textarea-single">Spam</textarea>
+        <textarea id="textarea-multi">Spam
+<b>Eggs</b>
+Bacon</textarea>
     '''
 
     html4 = '''
@@ -470,12 +473,20 @@ class TestManipulating(TestCase):
 
     def test_val_for_textarea(self):
         d = pq(self.html3)
-        self.assertEqual(d('textarea').val(), 'Spam')
-        self.assertEqual(d('textarea').text(), 'Spam')
-        d('textarea').val('42')
-        self.assertEqual(d('textarea').val(), '42')
+        self.assertEqual(d('#textarea-single').val(), 'Spam')
+        self.assertEqual(d('#textarea-single').text(), 'Spam')
+        d('#textarea-single').val('42')
+        self.assertEqual(d('#textarea-single').val(), '42')
         # Note: jQuery still returns 'Spam' here.
-        self.assertEqual(d('textarea').text(), '42')
+        self.assertEqual(d('#textarea-single').text(), '42')
+
+        multi_expected = '''Spam\n<b>Eggs</b>\nBacon'''
+        self.assertEqual(d('#textarea-multi').val(), multi_expected)
+        self.assertEqual(d('#textarea-multi').text(), multi_expected)
+        multi_new = '''Bacon\n<b>Eggs</b>\nSpam'''
+        d('#textarea-multi').val(multi_new)
+        self.assertEqual(d('#textarea-multi').val(), multi_new)
+        self.assertEqual(d('#textarea-multi').text(), multi_new)
 
     def test_val_for_select(self):
         d = pq(self.html4)


### PR DESCRIPTION
Currently, calling the `text()` or `val()` methods on a `textarea` element
strips all markup (and newlines). In jQuery, tag-like character sequences in a `textarea`
element are preserved.

For example, calling `$('textarea').text()` or `.val()` on
`<textarea>This <b>is</b> preserved</textarea>` => `This <b>is</b> preserved`

A few tests have been added to check this behavior.