### PR TITLE
web scraping improvements: default timeout and session support

### DIFF
--- a/docs/scrap.rst
+++ b/docs/scrap.rst
@@ -19,4 +19,15 @@ If `requests`_ is installed then it will use it. This allow you to use most of `
   >>> pq(your_url, {'q': 'foo'}, method='post', verify=True)
   [<html>]
 
+
+Timeout
+-------
+
+The default timeout is 60 seconds, you can change it by setting the timeout parameter which is forwarded to the underlying urllib or requests library.
+
+Session
+-------
+
+When using the requests library you can instantiate a Session object which keeps state between http calls (for example - to keep cookies). You can set the session parameter to use this session object.
+
 .. _requests: http://docs.python-requests.org/en/latest/


### PR DESCRIPTION
Added a couple of necessary features for web scraping:

* support for `timeout` parameter with default timeout of 60 seconds (supported for both urllib and requests)
* support for `session` parameter to allow providing a [requests session object](http://docs.python-requests.org/en/master/user/advanced/#session-objects) for persistence between requests (e.g. to keep cookies)

regarding setting a default timeout - see this comment and discussion - https://github.com/requests/requests/issues/3070#issuecomment-318949822