### PR TITLE
remove() no longer adds a space

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Add nextUntil method
 
+- ``.remove()`` no longer inserts a space in place of the removed element
+
 
 1.4.3 (2020-11-21)
 ------------------

--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1456,7 +1456,7 @@ class PyQuery(list):
              >>> d('strong').remove()
              [<strong>]
              >>> print(d)
-             <div>Maybe <em>she</em> does   know</div>
+             <div>Maybe <em>she</em> does  know</div>
         """
         if expr is no_default:
             for tag in self:
@@ -1467,11 +1467,11 @@ class PyQuery(list):
                         if prev is None:
                             if not parent.text:
                                 parent.text = ''
-                            parent.text += ' ' + tag.tail
+                            parent.text += tag.tail
                         else:
                             if not prev.tail:
                                 prev.tail = ''
-                            prev.tail += ' ' + tag.tail
+                            prev.tail += tag.tail
                     parent.remove(tag)
         else:
             results = self._copy(expr, self)

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -491,9 +491,9 @@ Bacon</textarea>
         d = pq(self.html)
         d('img').remove()
         val = d('a:first').html()
-        assert val == 'Test My link text', repr(val)
+        assert val == 'TestMy link text', repr(val)
         val = d('a:last').html()
-        assert val == ' My link text 2', repr(val)
+        assert val == 'My link text 2', repr(val)
 
     def test_class(self):
         d = pq('<div></div>')


### PR DESCRIPTION
In PyQuery, `remove()` currently adds a space in place of the removed element:

```
>>> print(PyQuery('<a>1<b>2</b>3</a>').remove('b'))
<a>1 3</a>
```

The same line in jQuery would print `<a>12</a>`.

I think jQuery's behavior is correct here, because the new space will sometimes change the semantics of the document. And it's possible to manually add a space after the target element before removing it, if you want a space, but not possible to manually remove the space if you don't want it.

So, this PR removes the extra space from `remove()`.