### PR TITLE
Escape entities in html() output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Add nextUntil method
 
+- Fix escaping of top-level element text in ``.html()`` output
+
 
 1.4.3 (2020-11-21)
 ------------------

--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin
 from .openers import url_opener
 from .text import extract_text
 from copy import deepcopy
+from html import escape
 from lxml import etree
 import lxml.html
 import inspect
@@ -1085,9 +1086,9 @@ class PyQuery(list):
                 return None
             tag = self[0]
             children = tag.getchildren()
+            html = escape(tag.text or '', quote=False)
             if not children:
-                return tag.text or ''
-            html = tag.text or ''
+                return html
             if 'encoding' not in kwargs:
                 kwargs['encoding'] = str
             html += u''.join([etree.tostring(e, **kwargs)

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -534,9 +534,10 @@ Bacon</textarea>
         self.assertEqual(d('#textarea-multi').val(), multi_expected)
         self.assertEqual(d('#textarea-multi').text(), multi_expected)
         multi_new = '''Bacon\n<b>Eggs</b>\nSpam'''
+        multi_new_expected = '''Bacon\n&lt;b&gt;Eggs&lt;/b&gt;\nSpam'''
         d('#textarea-multi').val(multi_new)
-        self.assertEqual(d('#textarea-multi').val(), multi_new)
-        self.assertEqual(d('#textarea-multi').text(), multi_new)
+        self.assertEqual(d('#textarea-multi').val(), multi_new_expected)
+        self.assertEqual(d('#textarea-multi').text(), multi_new_expected)
 
     def test_val_for_select(self):
         d = pq(self.html4)
@@ -621,6 +622,13 @@ Bacon</textarea>
         new_html = d.outerHtml()
         self.assertEqual(new_html, expected)
         self.assertIn(replacement, new_html)
+
+    def test_html_escape(self):
+        inner_html = 'encoded &lt;script&gt; tag with "quotes".' \
+                     '<span>nested &lt;tag&gt;</span>'
+        html = '<div>' + inner_html + '</div>'
+        d = pq(html)
+        self.assertEqual(d.html(), inner_html)
 
 
 class TestAjax(TestCase):


### PR DESCRIPTION
Currently the `.html()` method does not escape the `tag.text` portion of the response:

```
In [1]: pq('<div>encoded &lt;script&gt; tag</div>').html()
Out[1]: 'encoded <script> tag'
```

This PR updates `.html()` to call the builtin `html.escape()` function on `tag.text`. We can set `quote=False` because we're escaping element text rather than attribute text.

Fixes #205 #218 #200 #178