### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/pseudo_classes.rst
+++ b/docs/pseudo_classes.rst
@@ -182,7 +182,7 @@ Matches elements which contain at least one element that matches
 :header
 ==================
 
-Matches all header elelements (h1, ..., h6)::
+Matches all header elements (h1, ..., h6)::
 
         >>> from pyquery import PyQuery
         >>> d = PyQuery('<div><h1>title</h1></div>')

--- a/pyquery/cssselectpatch.py
+++ b/pyquery/cssselectpatch.py
@@ -321,7 +321,7 @@ class JQueryTranslator(cssselect_xpath.HTMLTranslator):
         return xpath
 
     def xpath_header_pseudo(self, xpath):
-        """Matches all header elelements (h1, ..., h6)::
+        """Matches all header elements (h1, ..., h6)::
 
             >>> from pyquery import PyQuery
             >>> d = PyQuery('<div><h1>title</h1></div>')

--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -266,7 +266,7 @@ class PyQuery(list):
         return self._copy(self[:] + other[:])
 
     def extend(self, other):
-        """Extend with anoter PyQuery object"""
+        """Extend with another PyQuery object"""
         assert isinstance(other, self.__class__)
         self._extend(other[:])
         return self

--- a/pyquery/text.py
+++ b/pyquery/text.py
@@ -77,7 +77,7 @@ def extract_text_array(dom, squash_artifical_nl=True, strip_artifical_nl=True):
     if dom.tag in SEPARATORS:
         r.append(True)  # equivalent of '\n' used to designate separators
     elif dom.tag not in INLINE_TAGS:
-        # equivalent of '\n' used to designate artifically inserted newlines
+        # equivalent of '\n' used to designate artificially inserted newlines
         r.append(None)
     if dom.text is not None:
         r.append(dom.text)
@@ -87,7 +87,7 @@ def extract_text_array(dom, squash_artifical_nl=True, strip_artifical_nl=True):
         if child.tail is not None:
             r.append(child.tail)
     if dom.tag not in INLINE_TAGS and dom.tag not in SEPARATORS:
-        # equivalent of '\n' used to designate artifically inserted newlines
+        # equivalent of '\n' used to designate artificially inserted newlines
         r.append(None)
     if squash_artifical_nl:
         r = _squash_artifical_nl(r)


### PR DESCRIPTION
There are small typos in:
- docs/pseudo_classes.rst
- pyquery/cssselectpatch.py
- pyquery/pyquery.py
- pyquery/text.py

Fixes:
- Should read `elements` rather than `elelements`.
- Should read `artificially` rather than `artifically`.
- Should read `another` rather than `anoter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md