### PR TITLE
test: allow libxml2 behavior change

### DIFF
--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -857,7 +857,8 @@ class TestXMLNamespace(TestCase):
 
     def test_selector_html(self):
         expected = 'What'
-        d = pq('blah', self.xml.split('?>', 1)[1], parser='html')
+        query = 'blah' if etree.LIBXML_VERSION < (2, 10, 4) else 'bar\:blah'
+        d = pq(query, self.xml.split('?>', 1)[1], parser='html')
         val = d.text()
         self.assertEqual(repr(val), repr(expected))
 


### PR DESCRIPTION
As mentioned in #248, libxml2 2.10.4 contains breaking change.

This PR fixes it by allowing this breaking change. 

**Warning**: Please reconsider it before merging this request as this means that we allow libxml2 breaking changes propagate to users of pyquery.

Close #248.