### PR TITLE
fix: treat empty HTML strings as an empty document

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -67,6 +67,9 @@ def build_camel_case_aliases(PyQuery):
 def fromstring(context, parser=None, custom_parser=None):
     """use html parser if we don't have clean xml
     """
+    # Empty/whitespace-only markup → empty document (jQuery $('') parity).
+    if isinstance(context, basestring) and not context.strip():
+        return []
     if hasattr(context, 'read') and hasattr(context.read, '__call__'):
         meth = 'parse'
     else:

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -351,6 +351,14 @@ class TestConstruction(TestCase):
     def test_typeerror_on_invalid_value(self):
         self.assertRaises(TypeError, pq, object())
 
+    def test_empty_string_returns_empty_doc(self):
+        """Empty/whitespace markup must not raise ParserError."""
+        for markup in ('', '   ', '\n', '\t  \n'):
+            doc = pq(markup)
+            self.assertEqual(len(doc), 0)
+            self.assertEqual(doc.html(), None)
+            self.assertEqual(list(doc), [])
+
 
 class TestComment(TestCase):
 


### PR DESCRIPTION
pyquery.PyQuery.__init__ hits ParserError when empty or whitespace-only HTML string. This PR fixes the regression with a focused test covering the case.
