### PR TITLE
fix: accept dict attribute mappings in attr()

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -768,7 +768,8 @@ class PyQuery(list):
         length = len(args)
         if length == 1:
             attr = args[0]
-            attr = mapping.get(attr, attr)
+            if not isinstance(attr, dict):
+                attr = mapping.get(attr, attr)
         elif length == 2:
             attr, value = args
             attr = mapping.get(attr, attr)
@@ -784,7 +785,7 @@ class PyQuery(list):
         elif isinstance(attr, dict):
             for tag in self:
                 for key, value in attr.items():
-                    tag.set(key, value)
+                    tag.set(mapping.get(key, key), value)
         elif value is no_default:
             return self[0].get(attr)
         elif value is None:

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -489,6 +489,15 @@ Bacon</textarea>
         self.assertEqual(d.outer_html(), '<div value=""></div>')
         self.assertEqual(d.outer_html(method="xml"), '<div value=""/>')
 
+    def test_attr_dict_mapping(self):
+        d = pq('<div>')
+        d.attr({'id': 'x', 'class_': 'y', 'data-a': '1'})
+        self.assertEqual(d.attr('id'), 'x')
+        self.assertEqual(d.attr('class'), 'y')
+        self.assertEqual(d.attr('data-a'), '1')
+        self.assertEqual(d.attr(id='z', class_='w').attr('id'), 'z')
+        self.assertEqual(d.attr('class'), 'w')
+
     def test_remove(self):
         d = pq(self.html)
         d('img').remove()


### PR DESCRIPTION
PyQuery.attr hits TypeError when attr({dict}) mapping.get unhashable. This PR fixes the regression with a focused test covering the case.
