### PR TITLE
fix: use option text when select value attribute is missing

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1001,6 +1001,11 @@ class PyQuery(list):
             ['you', 'hou']
 
         """
+        def _option_value(option):
+            # Missing value attr uses option text (HTML / jQuery).
+            val = option.attr('value')
+            return option.text() if val is None else val
+
         def _get_value(tag):
             # <textarea>
             if tag.tag == 'textarea':
@@ -1012,13 +1017,15 @@ class PyQuery(list):
                     selected = self._copy(tag)('option[selected]')
                     # Rebuild list to avoid serialization error
                     return list(selected.map(
-                        lambda _, o: self._copy(o).attr('value')
+                        lambda _, o: _option_value(self._copy(o))
                     ))
                 selected_option = self._copy(tag)('option[selected]:last')
                 if selected_option:
-                    return selected_option.attr('value')
-                else:
-                    return self._copy(tag)('option').attr('value')
+                    return _option_value(selected_option)
+                first = self._copy(tag)('option:first')
+                if first:
+                    return _option_value(first)
+                return None
             # <input type="checkbox"> or <input type="radio">
             elif self.is_(':checkbox,:radio'):
                 val = self._copy(tag).attr('value')

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -594,6 +594,27 @@ Bacon</textarea>
         self.assertEqual(d('#second').val(), '42')
         self.assertEqual(d('#third').val(), '42')
 
+    def test_val_select_option_without_value_attr(self):
+        d = pq('<select><option>a</option><option selected>b</option></select>')
+        self.assertEqual(d.val(), 'b')
+        d = pq('<select><option>first</option><option>second</option></select>')
+        self.assertEqual(d.val(), 'first')
+        d = pq('<select><option selected value="">empty</option></select>')
+        self.assertEqual(d.val(), '')
+        d = pq(
+            '<select multiple>'
+            '<option selected>a</option>'
+            '<option selected>b</option>'
+            '</select>'
+        )
+        self.assertEqual(d.val(), ['a', 'b'])
+        form = pq(
+            '<form><select name="s">'
+            '<option>t1</option><option selected>t2</option>'
+            '</select></form>'
+        )
+        self.assertEqual(form.serialize_pairs(), [('s', 't2')])
+
     def test_val_checkbox_no_value_attribute(self):
         d = pq('<input type="checkbox">')
         self.assertEqual(d.val(), 'on')


### PR DESCRIPTION
PyQuery.val hits DataLoss when option without value attribute returns None/empty. This PR fixes the regression with a focused test covering the case.
