### PR TITLE
fix: serialize text nodes in PyQuery str/html

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -344,12 +344,12 @@ class PyQuery(list):
                     el.tag = el.tag.split('}', 1)[1]
         return self
 
-    def _serialize_nodes(self, dumps):
+    def _serialize_nodes(self, dumps, method):
         # Text nodes from contents() cannot go through tostring.
         has_text_nodes = any(isinstance(e, str) for e in self)
         return ''.join(
             e if isinstance(e, str) else dumps(
-                e, encoding=str, with_tail=not has_text_nodes)
+                e, encoding=str, method=method, with_tail=not has_text_nodes)
             for e in self
         )
 
@@ -362,11 +362,11 @@ class PyQuery(list):
             <script>&lt;![[CDATA[ ]&gt;</script>
 
         """
-        return self._serialize_nodes(etree.tostring)
+        return self._serialize_nodes(etree.tostring, method='xml')
 
     def __unicode__(self):
         """xml representation of current nodes"""
-        return self._serialize_nodes(etree.tostring)
+        return self._serialize_nodes(etree.tostring, method='xml')
 
     def __html__(self):
         """html representation of current nodes::
@@ -377,7 +377,7 @@ class PyQuery(list):
             <script><![[CDATA[ ]></script>
 
         """
-        return self._serialize_nodes(lxml.html.tostring)
+        return self._serialize_nodes(lxml.html.tostring, method='html')
 
     def __repr__(self):
         r = []

--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -353,12 +353,21 @@ class PyQuery(list):
             <script>&lt;![[CDATA[ ]&gt;</script>
 
         """
-        return ''.join([etree.tostring(e, encoding=str) for e in self])
+        has_text_nodes = any(isinstance(e, str) for e in self)
+        return ''.join(
+            e if isinstance(e, str) else etree.tostring(
+                e, encoding=str, with_tail=not has_text_nodes)
+            for e in self
+        )
 
     def __unicode__(self):
         """xml representation of current nodes"""
-        return u''.join([etree.tostring(e, encoding=str)
-                         for e in self])
+        has_text_nodes = any(isinstance(e, str) for e in self)
+        return u''.join(
+            e if isinstance(e, str) else etree.tostring(
+                e, encoding=str, with_tail=not has_text_nodes)
+            for e in self
+        )
 
     def __html__(self):
         """html representation of current nodes::
@@ -369,8 +378,12 @@ class PyQuery(list):
             <script><![[CDATA[ ]></script>
 
         """
-        return u''.join([lxml.html.tostring(e, encoding=str)
-                         for e in self])
+        has_text_nodes = any(isinstance(e, str) for e in self)
+        return u''.join(
+            e if isinstance(e, str) else lxml.html.tostring(
+                e, encoding=str, with_tail=not has_text_nodes)
+            for e in self
+        )
 
     def __repr__(self):
         r = []

--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -344,6 +344,15 @@ class PyQuery(list):
                     el.tag = el.tag.split('}', 1)[1]
         return self
 
+    def _serialize_nodes(self, dumps):
+        # Text nodes from contents() cannot go through tostring.
+        has_text_nodes = any(isinstance(e, str) for e in self)
+        return ''.join(
+            e if isinstance(e, str) else dumps(
+                e, encoding=str, with_tail=not has_text_nodes)
+            for e in self
+        )
+
     def __str__(self):
         """xml representation of current nodes::
 
@@ -353,21 +362,11 @@ class PyQuery(list):
             <script>&lt;![[CDATA[ ]&gt;</script>
 
         """
-        has_text_nodes = any(isinstance(e, str) for e in self)
-        return ''.join(
-            e if isinstance(e, str) else etree.tostring(
-                e, encoding=str, with_tail=not has_text_nodes)
-            for e in self
-        )
+        return self._serialize_nodes(etree.tostring)
 
     def __unicode__(self):
         """xml representation of current nodes"""
-        has_text_nodes = any(isinstance(e, str) for e in self)
-        return u''.join(
-            e if isinstance(e, str) else etree.tostring(
-                e, encoding=str, with_tail=not has_text_nodes)
-            for e in self
-        )
+        return self._serialize_nodes(etree.tostring)
 
     def __html__(self):
         """html representation of current nodes::
@@ -378,12 +377,7 @@ class PyQuery(list):
             <script><![[CDATA[ ]></script>
 
         """
-        has_text_nodes = any(isinstance(e, str) for e in self)
-        return u''.join(
-            e if isinstance(e, str) else lxml.html.tostring(
-                e, encoding=str, with_tail=not has_text_nodes)
-            for e in self
-        )
+        return self._serialize_nodes(lxml.html.tostring)
 
     def __repr__(self):
         r = []

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -359,6 +359,19 @@ class TestComment(TestCase):
         self.assertEqual(doc.text(), 'bar')
 
 
+class TestContentsStr(TestCase):
+
+    def test_str_contents_with_text_nodes(self):
+        doc = pq('hello <b>bold</b> world')
+        contents = doc.contents()
+        self.assertEqual(str(contents), 'hello <b>bold</b> world')
+        self.assertEqual(contents.__html__(), 'hello <b>bold</b> world')
+
+    def test_str_contents_text_only(self):
+        doc = pq('<div>only text</div>')
+        self.assertEqual(str(doc.contents()), 'only text')
+
+
 class TestCallback(TestCase):
     html = """
         <ol>


### PR DESCRIPTION
PyQuery.__str__ hits TypeError when contents() includes text nodes. This PR fixes the regression with a focused test covering the case.
