### PR TITLE
fix: serialize forms whose id contains CSS metacharacters

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -1590,11 +1590,24 @@ class PyQuery(list):
             if el[0].tag == 'form':
                 form_id = el.attr('id')
                 if form_id:
-                    # Include inputs outside of their form owner
+                    # Avoid #id selectors: HTML ids may contain CSS metacharacters.
                     root = self._copy(el.root.getroot())
-                    controls.extend(root(
-                        '#%s :not([form]):input, [form="%s"]:input'
-                        % (form_id, form_id)))
+                    form_elem = el[0]
+                    matched = []
+                    for tag in root(':input'):
+                        owner = tag.get('form')
+                        if owner is not None:
+                            if owner == form_id:
+                                matched.append(tag)
+                            continue
+                        parent = tag.getparent()
+                        while parent is not None:
+                            if parent is form_elem:
+                                matched.append(tag)
+                                break
+                            parent = parent.getparent()
+                    if matched:
+                        controls.extend(self._copy(matched))
                 else:
                     controls.extend(el(':not([form]):input'))
             elif el[0].tag == 'fieldset':

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -765,6 +765,36 @@ of text</textarea>
             ('spam', 'Spam'),
         ])
 
+    def test_serialize_pairs_form_id_css_metacharacters(self):
+        # HTML ids may contain CSS metacharacters; #id is not a literal match.
+        html = (
+            '<form id="a.b">'
+            '<input name="in" value="1">'
+            '</form>'
+            '<input form="a.b" name="out" value="2">'
+        )
+        self.assertEqual(pq(html)('form').serialize_pairs(), [
+            ('in', '1'), ('out', '2'),
+        ])
+        html_colon = (
+            '<form id="a:b">'
+            '<input name="in" value="1">'
+            '</form>'
+            '<input form="a:b" name="out" value="2">'
+        )
+        self.assertEqual(pq(html_colon)('form').serialize_pairs(), [
+            ('in', '1'), ('out', '2'),
+        ])
+        html_quote = (
+            '<form id="a&quot;b">'
+            '<input name="in" value="1">'
+            '</form>'
+            '<input form=\'a"b\' name="out" value="2">'
+        )
+        self.assertEqual(pq(html_quote)('form').serialize_pairs(), [
+            ('in', '1'), ('out', '2'),
+        ])
+
     def test_serialize_pairs_form_controls(self):
         d = pq(self.html2)
         self.assertEqual(d('fieldset').serialize_pairs(), [


### PR DESCRIPTION
`serialize_pairs` builds `#id` CSS to find controls. HTML ids can contain `.` / `:` / `"`, so those forms drop fields or raise `ExpressionError`.

```python
from pyquery import PyQuery as pq
pq('<form id="a.b"><input name="in" value="1"></form>')('form').serialize_pairs()
# []  (expected [('in', '1')])
pq('<form id="a:b"><input name="in" value="1"></form>')('form').serialize_pairs()
# ExpressionError
```

Match controls by `form=` / ancestry instead of `#id`.