### PR TITLE
Fix :lt() argument error message naming :gt()

### DIFF
--- a/pyquery/cssselectpatch.py
+++ b/pyquery/cssselectpatch.py
@@ -415,7 +415,7 @@ class JQueryTranslator(cssselect_xpath.HTMLTranslator):
         """
         if function.argument_types() != ['NUMBER']:
             raise ExpressionError(
-                "Expected a single integer for :gt(), got %r" % (
+                "Expected a single integer for :lt(), got %r" % (
                     function.arguments,))
 
         value = int(function.arguments[0].value)

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -189,6 +189,11 @@ class TestSelector(TestCase):
         self.assertEqual(e('div:lt(1)').text(), 'node1')
         self.assertEqual(e('div:eq(2)').text(), 'node3')
 
+        # A non-integer :lt() argument must name :lt() in the error, not :gt().
+        from cssselect.xpath import ExpressionError
+        with self.assertRaisesRegex(ExpressionError, r':lt\('):
+            e('div:lt("a")')
+
         # test on the form
         e = self.klass(self.html4)
         disabled = e(':disabled')


### PR DESCRIPTION
### Summary

`xpath_lt_function` (the `:lt()` pseudo-class) raises an argument-validation error that names the wrong selector — its message was copy-pasted from `xpath_gt_function`:

```python
def xpath_lt_function(self, xpath, function):  # :lt()
    if function.argument_types() != ['NUMBER']:
        raise ExpressionError(
            "Expected a single integer for :gt(), got %r" % (   # says :gt()
                function.arguments,))
```

So a bad `:lt()` argument reports `:gt()`:

```python
>>> PyQuery('<div><h1/></div>')('h1:lt("a")')
ExpressionError: Expected a single integer for :gt(), got [<STRING 'a' at 6>]
```

### Fix

Name `:lt()` in the message, consistent with the sibling `xpath_eq_function` (`:eq()`) and `xpath_gt_function` (`:gt()`), which each name their own pseudo-class.

### Tests

Added an assertion to `test_pseudo_classes` that a non-integer `:lt()` argument raises an `ExpressionError` naming `:lt()`. Full `tests/test_pyquery.py` passes locally (70 passed, 4 network-skipped); `ruff check` clean.
