### PR TITLE
Add missing HTML inline elements to INLINE_TAGS

### DIFF
--- a/pyquery/text.py
+++ b/pyquery/text.py
@@ -3,10 +3,13 @@ import re
 
 # https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#Elements
 INLINE_TAGS = {
-    'a', 'abbr', 'acronym', 'b', 'bdo', 'big', 'br', 'button', 'cite',
-    'code', 'dfn', 'em', 'i', 'img', 'input', 'kbd', 'label', 'map',
-    'object', 'q', 'samp', 'script', 'select', 'small', 'span', 'strong',
-    'sub', 'sup', 'textarea', 'time', 'tt', 'var'
+    'a', 'abbr', 'acronym', 'audio', 'b', 'bdi', 'bdo', 'big', 'br',
+    'button', 'canvas', 'cite', 'code', 'data', 'datalist', 'del', 'dfn',
+    'em', 'embed', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label',
+    'map', 'mark', 'meter', 'noscript', 'object', 'output', 'picture',
+    'progress', 'q', 'ruby', 's', 'samp', 'script', 'select', 'slot',
+    'small', 'span', 'strong', 'sub', 'sup', 'svg', 'template',
+    'textarea', 'time', 'tt', 'u', 'var', 'video', 'wbr'
 }
 
 SEPARATORS = {'br'}

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -367,6 +367,17 @@ class TestComment(TestCase):
         self.assertEqual(doc.text(), 'bar')
 
 
+class TestInlineTags(TestCase):
+
+    def test_text_does_not_break_around_inline_elements(self):
+        for tag in ('audio', 'bdi', 'canvas', 'data', 'datalist', 'del',
+                    'embed', 'iframe', 'ins', 'mark', 'meter', 'noscript',
+                    'output', 'picture', 'progress', 'ruby', 's', 'slot',
+                    'svg', 'template', 'u', 'video', 'wbr'):
+            doc = pq('<p>foo<{0}>bar</{0}>baz</p>'.format(tag))
+            self.assertEqual(doc.text(), 'foobarbaz', tag)
+
+
 class TestContentsStr(TestCase):
 
     def test_str_contents_with_text_nodes(self):


### PR DESCRIPTION
Closes #253

`text()` inserts an artificial newline around any tag not listed in `INLINE_TAGS`, so inline elements missing from that set (`del`, `ins`, `mark`, `s`, `u`, `bdi`, `data`, `output`, `video`, `audio`, `canvas`, `iframe`, `svg`, ...) made `text()` split one line into several — e.g. `pq('<p>foo<del>bar</del>baz</p>').text()` returned `'foo\nbar\nbaz'` instead of `'foobarbaz'`.

This adds the inline elements from the MDN list in the issue that were absent, plus a regression test covering them (fails before, passes after). Full `tests/test_pyquery.py` is green.
