### PR TITLE
Support negative indexes in the :eq() selector

### DIFF
--- a/pyquery/cssselectpatch.py
+++ b/pyquery/cssselectpatch.py
@@ -375,6 +375,11 @@ class JQueryTranslator(cssselect_xpath.HTMLTranslator):
             >>> d('h1:eq(1)')
             [<h1.last>]
 
+        A negative index counts back from the last element::
+
+            >>> d('h1:eq(-1)')
+            [<h1.last>]
+
         ..
         """
         if function.argument_types() != ['NUMBER']:
@@ -382,7 +387,12 @@ class JQueryTranslator(cssselect_xpath.HTMLTranslator):
                 "Expected a single integer for :eq(), got %r" % (
                     function.arguments,))
         value = int(function.arguments[0].value)
-        xpath.add_post_condition('position() = %s' % (value + 1))
+        if value < 0:
+            xpath.add_post_condition(
+                'position() = last()%s' % (
+                    '%+d' % (value + 1) if value != -1 else ''))
+        else:
+            xpath.add_post_condition('position() = %s' % (value + 1))
         return xpath
 
     def xpath_gt_function(self, xpath, function):

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -219,6 +219,13 @@ class TestSelector(TestCase):
         assert len(e(":empty")) == 1
         assert len(e(":contains('Heading')")) == 8
 
+    def test_eq_negative_index(self):
+        e = self.klass(self.html)
+        self.assertEqual(e('div:eq(-1)').text(), 'node3')
+        self.assertEqual(e('div:eq(-2)').text(), 'node2')
+        self.assertEqual(e('div:eq(-3)').text(), 'node1')
+        self.assertEqual(e('div:eq(-4)').text(), '')
+
     def test_on_the_fly_dom_creation(self):
         e = self.klass(self.html)
         assert e('<p>Hello world</p>').text() == 'Hello world'


### PR DESCRIPTION
Closes #236

`:eq(-1)` silently matched nothing instead of the last element, because `xpath_eq_function` always emitted `position() = value + 1` and a negative argument yields a position that can never match. jQuery counts a negative `:eq()` index from the end, and pyquery's own `.eq(-1)` method already does — only the selector form was inconsistent.

Negative values now translate to `position() = last()-n`; the non-negative path is unchanged.
