### PR TITLE
Accept a PyQuery object as the filter() selector

### DIFF
--- a/pyquery/pyquery.py
+++ b/pyquery/pyquery.py
@@ -613,7 +613,17 @@ class PyQuery(list):
             [<p.hello>]
             >>> d('p').filter(lambda i, this: PyQuery(this).text() == 'Hi')
             [<p.hello>]
+
+        A PyQuery object may also be used, keeping the elements of self that
+        are also part of it:
+
+            >>> d('p').filter(d('.hello'))
+            [<p.hello>]
         """
+        if isinstance(selector, self.__class__):
+            keep = {id(el) for el in selector}
+            return self._copy([el for el in self if id(el) in keep],
+                              parent=self)
         if not hasattr(selector, '__call__'):
             return self._filter_only(selector, self)
         else:

--- a/tests/test_pyquery.py
+++ b/tests/test_pyquery.py
@@ -266,6 +266,11 @@ class TestTraversal(TestCase):
         d = pq('<p>Hello <b>warming</b> world</p>')
         self.assertEqual(d('strong').filter(lambda el: True), [])
 
+    def test_filter_pyquery_object(self):
+        d = pq('<div page="1">a</div><div page="2">b</div>')
+        self.assertEqual(d('div').filter(d('[page="2"]')), d('[page="2"]'))
+        self.assertEqual(d('div').filter(pq('<div page="3">c</div>')), [])
+
     def test_not(self):
         assert len(self.klass('div', self.html).not_('.node3')) == 1
 


### PR DESCRIPTION
Closes #232

`filter()` only handled a selector string or a callable, so passing another PyQuery object (which jQuery supports) fell into the callable branch and raised `AttributeError: 'PyQuery' object has no attribute '__globals__'`. A PyQuery argument is now intersected with the current selection by element identity.
